### PR TITLE
FAI-3436 Show transferred funds on payment details

### DIFF
--- a/src/SFA.DAS.EmployerFinance.Database/StoredProcedures/GetPaymentDetail_ByAccountProviderAndDateRange.sql
+++ b/src/SFA.DAS.EmployerFinance.Database/StoredProcedures/GetPaymentDetail_ByAccountProviderAndDateRange.sql
@@ -19,7 +19,8 @@ AS
 		MIN(t.DateCreated) AS DateCreated,
 		SUM(CASE WHEN p.FundingSource IN (1, 5) THEN p.Amount END) * -1 AS LineAmount,
 		SUM(CASE WHEN p.FundingSource = 2 THEN p.Amount END) * -1 AS SfaCoInvestmentAmount,
-		SUM(CASE WHEN p.FundingSource = 3 THEN p.Amount END) * -1 AS EmployerCoInvestmentAmount
+		SUM(CASE WHEN p.FundingSource = 3 THEN p.Amount END) * -1 AS EmployerCoInvestmentAmount,
+        t.TransferSenderAccountName as SenderAccountName
 	FROM [employer_financial].[Payment] p
 	LEFT JOIN [employer_financial].[PaymentMetaData] pm ON pm.Id = p.PaymentMetaDataId
 	INNER JOIN [employer_financial].[TransactionLine] t ON t.AccountId = p.AccountId AND t.PeriodEnd = p.PeriodEnd AND t.Ukprn = p.Ukprn
@@ -28,4 +29,4 @@ AS
 	AND p.FundingSource IN (1, 2, 3, 5)
 	AND t.DateCreated >= @fromDate
 	AND t.DateCreated <= @toDate
-	GROUP BY p.PeriodEnd, pm.ApprenticeshipCourseName, pm.ApprenticeshipCourseLevel, pm.PathwayName, pm.PathwayCode, pm.LearningType
+	GROUP BY p.PeriodEnd, pm.ApprenticeshipCourseName, pm.ApprenticeshipCourseLevel, pm.PathwayName, pm.PathwayCode, pm.LearningType, t.TransferSenderAccountName

--- a/src/SFA.DAS.EmployerFinance.UnitTests/Queries/FindEmployerAccountPaymentTransactionDetailsTests/WhenIGetEmployerPaymentTransactionDetails.cs
+++ b/src/SFA.DAS.EmployerFinance.UnitTests/Queries/FindEmployerAccountPaymentTransactionDetailsTests/WhenIGetEmployerPaymentTransactionDetails.cs
@@ -9,6 +9,7 @@ namespace SFA.DAS.EmployerFinance.UnitTests.Queries.FindEmployerAccountPaymentTr
 public class WhenIGetEmployerPaymentTransactionDetails : QueryBaseTest<FindAccountProviderPaymentsHandler, FindAccountProviderPaymentsQuery, FindAccountProviderPaymentsResponse>
 {
     private const string ProviderName = "Test Provider";
+    private const string SenderAccountName = "Test Sender Account";
 
     private Mock<IDasLevyService> _dasLevyService;
     private Mock<IEncodingService> _encodingService;
@@ -39,10 +40,9 @@ public class WhenIGetEmployerPaymentTransactionDetails : QueryBaseTest<FindAccou
         _dasLevyService = new Mock<IDasLevyService>();
         _dasLevyService.Setup(x => x.GetAccountProviderPaymentsByDateRange<PaymentTransactionLine>
                 (It.IsAny<long>(), It.IsAny<long>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(new []
-            {
-                new PaymentTransactionLine { ProviderName = ProviderName }
-            });
+            .ReturnsAsync([
+                    new PaymentTransactionLine { ProviderName = ProviderName, SenderAccountName = SenderAccountName }
+                ]);
 
         Query = new FindAccountProviderPaymentsQuery
         {
@@ -82,7 +82,7 @@ public class WhenIGetEmployerPaymentTransactionDetails : QueryBaseTest<FindAccou
     }
 
     [Test]
-    public void ThenAnUnauhtorizedExceptionIsThrownIfTheValidationResultReturnsUnauthorized()
+    public void ThenAnUnauthorizedExceptionIsThrownIfTheValidationResultReturnsUnauthorized()
     {
         //Arrange
         RequestValidator.Setup(x => x.ValidateAsync(It.IsAny<FindAccountProviderPaymentsQuery>()))
@@ -103,16 +103,25 @@ public class WhenIGetEmployerPaymentTransactionDetails : QueryBaseTest<FindAccou
     }
 
     [Test]
+    public async Task ThenTheSenderAccountNameShouldBeAddedToTheResponse()
+    {
+        //Act
+        var actual = await RequestHandler.Handle(Query, CancellationToken.None);
+
+        //Assert
+        actual.SenderAccountName.Should().Be(SenderAccountName);
+    }
+
+    [Test]
     public async Task ThenTheTransactionDateShouldBeAddedToTheResponse()
     {
         //Arrange
         var transactionDate = DateTime.Now.AddDays(-2);
         _dasLevyService.Setup(x => x.GetAccountProviderPaymentsByDateRange<PaymentTransactionLine>
                 (It.IsAny<long>(), It.IsAny<long>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(new []
-            {
+            .ReturnsAsync([
                 new PaymentTransactionLine {TransactionDate = transactionDate}
-            });
+            ]);
 
         //Act
         var actual = await RequestHandler.Handle(Query, CancellationToken.None);
@@ -127,7 +136,7 @@ public class WhenIGetEmployerPaymentTransactionDetails : QueryBaseTest<FindAccou
         //Arrange
         _dasLevyService.Setup(x => x.GetAccountProviderPaymentsByDateRange<PaymentTransactionLine>
                 (It.IsAny<long>(), It.IsAny<long>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(Array.Empty<PaymentTransactionLine>());
+            .ReturnsAsync([]);
 
         //Act
         var actual = await RequestHandler.Handle(Query, CancellationToken.None);

--- a/src/SFA.DAS.EmployerFinance.Web.UnitTests/Orchestrators/WhenGettingProviderPaymentSummary.cs
+++ b/src/SFA.DAS.EmployerFinance.Web.UnitTests/Orchestrators/WhenGettingProviderPaymentSummary.cs
@@ -84,7 +84,7 @@ public class WhenGettingProviderPaymentSummary
         var response = await _sut.GetProviderPaymentSummary("abc123", 888888, new DateTime(2019, 9, 1), new DateTime(2019, 9, 30));
 
         // Assert
-        response.Data.ShowNonCoInvesmentPaymentsTotal.Should().BeFalse();
+        response.Data.ShowNonCoInvestmentPaymentsTotal.Should().BeFalse();
     }
 
     [Test]
@@ -112,7 +112,7 @@ public class WhenGettingProviderPaymentSummary
         var response = await _sut.GetProviderPaymentSummary("abc123", 888888, new DateTime(2019, 9, 1), new DateTime(2019, 9, 30));
 
         // Assert
-        response.Data.ShowNonCoInvesmentPaymentsTotal.Should().BeTrue();
+        response.Data.ShowNonCoInvestmentPaymentsTotal.Should().BeTrue();
     }
 
     [Test]
@@ -135,7 +135,7 @@ public class WhenGettingProviderPaymentSummary
         var response = await _sut.GetProviderPaymentSummary("abc123", 888888, new DateTime(2019, 9, 1), new DateTime(2019, 9, 30));
 
         // Assert
-        response.Data.ShowNonCoInvesmentPaymentsTotal.Should().BeTrue();
+        response.Data.ShowNonCoInvestmentPaymentsTotal.Should().BeTrue();
     }
 
     private IEnumerable<PaymentTransactionLine> CreateCoursePayments(

--- a/src/SFA.DAS.EmployerFinance.Web/Controllers/EmployerAccountTransactionsController.cs
+++ b/src/SFA.DAS.EmployerFinance.Web/Controllers/EmployerAccountTransactionsController.cs
@@ -15,31 +15,17 @@ namespace SFA.DAS.EmployerFinance.Web.Controllers;
 [SetNavigationSection(NavigationSection.AccountsFinance)]
 [Route("accounts/{HashedAccountId}")]
 [Authorize(Policy = nameof(PolicyNames.HasEmployerViewerTransactorOwnerAccount))]
-public class EmployerAccountTransactionsController : Controller
+public class EmployerAccountTransactionsController(
+    IEmployerAccountTransactionsOrchestrator accountTransactionsOrchestrator,
+    IMapper mapper,
+    IMediator mediator,
+    IEncodingService encodingService)
+    : Controller
 {
-    private readonly IMapper _mapper;
-    private readonly IMediator _mediator;
-    private readonly IEncodingService _encodingService;
-
-    private readonly IEmployerAccountTransactionsOrchestrator _accountTransactionsOrchestrator;
-
-    public EmployerAccountTransactionsController(
-        IEmployerAccountTransactionsOrchestrator accountTransactionsOrchestrator,
-        IMapper mapper,
-        IMediator mediator,
-        IEncodingService encodingService)
-    {
-        _accountTransactionsOrchestrator = accountTransactionsOrchestrator;
-
-        _mapper = mapper;
-        _mediator = mediator;
-        _encodingService = encodingService;
-    }
-
     [Route("finance/provider/summary")]
     public async Task<IActionResult> ProviderPaymentSummary([FromRoute]string hashedAccountId, long ukprn, DateTime fromDate, DateTime toDate)
     {
-        var viewModel = await _accountTransactionsOrchestrator.GetProviderPaymentSummary(hashedAccountId, ukprn, fromDate, toDate);
+        var viewModel = await accountTransactionsOrchestrator.GetProviderPaymentSummary(hashedAccountId, ukprn, fromDate, toDate);
 
         return View(ControllerConstants.ProviderPaymentSummaryViewName, viewModel);
     }
@@ -48,7 +34,7 @@ public class EmployerAccountTransactionsController : Controller
     public async Task<IActionResult> Index([FromRoute]string hashedAccountId)
     {
 
-        var viewModel = await _accountTransactionsOrchestrator.Index(hashedAccountId, HttpContext.User.Identities.FirstOrDefault());
+        var viewModel = await accountTransactionsOrchestrator.Index(hashedAccountId, HttpContext.User.Identities.FirstOrDefault());
 
         if (viewModel.RedirectUrl != null)
             return Redirect(viewModel.RedirectUrl);
@@ -73,9 +59,9 @@ public class EmployerAccountTransactionsController : Controller
 
         try
         {
-            var response = await _mediator.Send(new GetTransactionsDownloadQuery
+            var response = await mediator.Send(new GetTransactionsDownloadQuery
             {
-                AccountId = _encodingService.Decode(hashedAccountId,EncodingType.AccountId),
+                AccountId = encodingService.Decode(hashedAccountId,EncodingType.AccountId),
                 DownloadFormat = model.DownloadFormat,
                 EndDate = model.EndDate,
                 StartDate = model.StartDate,
@@ -97,7 +83,7 @@ public class EmployerAccountTransactionsController : Controller
     [Route("finance/{year}/{month}", Name = RouteNames.TransactionsView)]
     public async Task<IActionResult> TransactionsView([FromRoute]string hashedAccountId, [FromRoute]int year, [FromRoute]int month)
     {
-        var transactionViewResult = await _accountTransactionsOrchestrator.GetAccountTransactions(hashedAccountId, year, month);
+        var transactionViewResult = await accountTransactionsOrchestrator.GetAccountTransactions(hashedAccountId, year, month);
 
         if (transactionViewResult.Data.Account == null)
         {
@@ -113,7 +99,7 @@ public class EmployerAccountTransactionsController : Controller
     [Route("finance/levyDeclaration/details")]
     public async Task<IActionResult> LevyDeclarationDetail([FromRoute]string hashedAccountId, DateTime fromDate, DateTime toDate)
     {
-        var viewModel = await _accountTransactionsOrchestrator.FindAccountLevyDeclarationTransactions(hashedAccountId, fromDate, toDate);
+        var viewModel = await accountTransactionsOrchestrator.FindAccountLevyDeclarationTransactions(hashedAccountId, fromDate, toDate);
 
         return View(ControllerConstants.LevyDeclarationDetailViewName, viewModel);
     }
@@ -129,7 +115,7 @@ public class EmployerAccountTransactionsController : Controller
     public async Task<IActionResult> CourseFrameworkPaymentSummary(string hashedAccountId, long ukprn, string courseName,
         int? courseLevel, int? pathwayCode, DateTime fromDate, DateTime toDate)
     {
-        var orchestratorResponse = await _accountTransactionsOrchestrator.GetCoursePaymentSummary(
+        var orchestratorResponse = await accountTransactionsOrchestrator.GetCoursePaymentSummary(
             hashedAccountId, ukprn, courseName, courseLevel, pathwayCode,
             fromDate, toDate);
 
@@ -139,11 +125,11 @@ public class EmployerAccountTransactionsController : Controller
     [Route("finance/transfer/details")]
     public async Task<IActionResult> TransferDetail([FromRoute]string hashedAccountId, GetTransferTransactionDetailsQuery query)
     {
-        query.AccountId = _encodingService.Decode(hashedAccountId, EncodingType.AccountId);
-        var response = await _mediator.Send(query);
+        query.AccountId = encodingService.Decode(hashedAccountId, EncodingType.AccountId);
+        var response = await mediator.Send(query);
         response.HashedAccountId = hashedAccountId;
 
-        var model = _mapper.Map<TransferTransactionDetailsViewModel>(response);
+        var model = mapper.Map<TransferTransactionDetailsViewModel>(response);
         return View(ControllerConstants.TransferDetailsViewName, model);
     }
     
@@ -151,7 +137,7 @@ public class EmployerAccountTransactionsController : Controller
     [Route("finance/expiredfunds/details")]
     public async Task<IActionResult> ExpiredFundsDetails([FromRoute]string hashedAccountId, DateTime fromDate, DateTime toDate)
     {
-        var viewModel = await _accountTransactionsOrchestrator.FindAccountExpiredFunds(hashedAccountId, fromDate, toDate);
+        var viewModel = await accountTransactionsOrchestrator.FindAccountExpiredFunds(hashedAccountId, fromDate, toDate);
 
         return View(ControllerConstants.ExpiredFundsDetailViewName, viewModel);
     }

--- a/src/SFA.DAS.EmployerFinance.Web/Orchestrators/EmployerAccountTransactionsOrchestrator.cs
+++ b/src/SFA.DAS.EmployerFinance.Web/Orchestrators/EmployerAccountTransactionsOrchestrator.cs
@@ -241,6 +241,7 @@ public class EmployerAccountTransactionsOrchestrator(
                     HashedAccountId = hashedAccountId,
                     UkPrn = ukprn,
                     ProviderName = providerPaymentsResponse.ProviderName,
+                    SenderAccountName = providerPaymentsResponse.SenderAccountName,
                     PaymentDate = providerPaymentsResponse.DateCreated,
                     FromDate = fromDate,
                     ToDate = toDate,

--- a/src/SFA.DAS.EmployerFinance.Web/ViewModels/ProviderPaymentsSummaryViewModel.cs
+++ b/src/SFA.DAS.EmployerFinance.Web/ViewModels/ProviderPaymentsSummaryViewModel.cs
@@ -7,6 +7,7 @@ public class ProviderPaymentsSummaryViewModel
     public string HashedAccountId { get; set; }
     public long UkPrn { get; set; }
     public string ProviderName { get; set; }
+    public string SenderAccountName { get; set; }
     public DateTime PaymentDate { get; set; }
     public DateTime FromDate { get; set; }
     public DateTime ToDate { get; set; }
@@ -28,5 +29,7 @@ public class ProviderPaymentsSummaryViewModel
     public decimal PaymentsTotalCourses => CoursePayments.Sum(p => p.TotalAmount);
     public decimal PaymentsTotalApprenticeshipUnits => ApprenticeshipUnitGroupSummaries.Sum(p => p.TotalAmount);
     public decimal PaymentsTotal => PaymentsTotalCourses + PaymentsTotalApprenticeshipUnits;
-    public bool ShowNonCoInvesmentPaymentsTotal => LevyPaymentsTotal != 0 || ApprenticeshipEmployerType == ApprenticeshipEmployerType.Levy;
+    public bool ShowNonCoInvestmentPaymentsTotal => LevyPaymentsTotal != 0 || ApprenticeshipEmployerType == ApprenticeshipEmployerType.Levy;
+    public bool ShowTransferSenderName => ApprenticeshipEmployerType != ApprenticeshipEmployerType.Levy &&
+                                          !string.IsNullOrEmpty(SenderAccountName);
 }

--- a/src/SFA.DAS.EmployerFinance.Web/Views/EmployerAccountTransactions/ProviderPaymentSummary.cshtml
+++ b/src/SFA.DAS.EmployerFinance.Web/Views/EmployerAccountTransactions/ProviderPaymentSummary.cshtml
@@ -28,6 +28,13 @@
                 <dt class="govuk-summary-list__key">Payment to</dt>
                 <dd class="govuk-summary-list__value">@Model.Data.ProviderName</dd>
             </div>
+            @if (Model.Data.ShowTransferSenderName)
+            {
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Transfer sender</dt>
+                    <dd class="govuk-summary-list__value">@Model.Data.SenderAccountName</dd>
+                </div>
+            }
         </dl>
     </div>
 </div>
@@ -35,13 +42,13 @@
 <table class="govuk-table das-table--responsive">
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-        <th class="govuk-table__header" colspan="@(Model.Data.ShowNonCoInvesmentPaymentsTotal ? "2" : "1")"></th>
+        <th class="govuk-table__header" colspan="@(Model.Data.ShowNonCoInvestmentPaymentsTotal ? "2" : "1")"></th>
         <th class="govuk-table__header app-table__cell--highlight app-table__cell--colgroup" scope="colgroup" colspan="2">Co-investment</th>
         <th class="govuk-table__header" colspan="2"></th>
     </tr>
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header das-table-cell-width-20">Course</th>
-        @if (Model.Data.ShowNonCoInvesmentPaymentsTotal)
+        @if (Model.Data.ShowNonCoInvestmentPaymentsTotal)
         {
             <th scope="col" class="govuk-table__header govuk-table__header--numeric das-table-cell-width-20">@(Model.Data.ApprenticeshipEmployerType == ApprenticeshipEmployerType.Levy ? "Paid from levy" : "Transferred funds")</th>
         }
@@ -56,11 +63,11 @@
     @if (Model.Data.CoursePayments.Count != 0)
     {
         <tr class="govuk-table__row app-table__row--highlight">
-            <td class="govuk-table__cell app-table__header-row-cell" colspan="@(Model.Data.ShowNonCoInvesmentPaymentsTotal ? "6" : "5")">Apprenticeship</td>
+            <td class="govuk-table__cell app-table__header-row-cell" colspan="@(Model.Data.ShowNonCoInvestmentPaymentsTotal ? "6" : "5")">Apprenticeship</td>
         </tr>
         @foreach (var coursePaymentSummary in Model.Data.CoursePayments)
         {
-            var coursePaymentsSummaryPartialViewModel = new CoursePaymentsSummaryPartialViewModel(coursePaymentSummary, Model.Data.HashedAccountId, Model.Data.UkPrn, Model.Data.FromDate, Model.Data.ToDate, Model.Data.ShowNonCoInvesmentPaymentsTotal);
+            var coursePaymentsSummaryPartialViewModel = new CoursePaymentsSummaryPartialViewModel(coursePaymentSummary, Model.Data.HashedAccountId, Model.Data.UkPrn, Model.Data.FromDate, Model.Data.ToDate, Model.Data.ShowNonCoInvestmentPaymentsTotal);
 
             <partial name="_TransactionPaymentLine" model="coursePaymentsSummaryPartialViewModel"/>
 
@@ -68,7 +75,7 @@
 
         <tr class="govuk-table__row">
             <td data-label="Totals" class="app-table__cell--transparent"> </td>
-            @if (Model.Data.ShowNonCoInvesmentPaymentsTotal)
+            @if (Model.Data.ShowNonCoInvestmentPaymentsTotal)
             {
                 <td data-label="Paid from levy" class="govuk-table__cell govuk-table__cell--numeric app-table__cell--total">@Model.Data.LevyPaymentsTotalCourses.ToString("C2", culture)</td>
             }
@@ -79,7 +86,7 @@
         </tr>
 
         <tr class="govuk-table__row app-table__row--spacer" aria-hidden="true">
-            <td class="app-table__cell--transparent" colspan="@(Model.Data.ShowNonCoInvesmentPaymentsTotal ? "2" : "1")">&nbsp;</td>
+            <td class="app-table__cell--transparent" colspan="@(Model.Data.ShowNonCoInvestmentPaymentsTotal ? "2" : "1")">&nbsp;</td>
             <td class="app-table__cell--transparent app-table__cell--highlight" colspan="2">&nbsp;</td>
             <td class="app-table__cell--transparent" colspan="2">&nbsp;</td>
         </tr>
@@ -89,19 +96,19 @@
     @if (Model.Data.ApprenticeshipUnitGroupSummaries.Count != 0)
     {
         <tr class="govuk-table__row app-table__row--highlight">
-            <td class="govuk-table__cell app-table__header-row-cell" colspan="@(Model.Data.ShowNonCoInvesmentPaymentsTotal ? "6" : "5")">Apprenticeship unit</td>
+            <td class="govuk-table__cell app-table__header-row-cell" colspan="@(Model.Data.ShowNonCoInvestmentPaymentsTotal ? "6" : "5")">Apprenticeship unit</td>
         </tr>
 
         @foreach (var apprenticeshipUnitGroupSummary in Model.Data.ApprenticeshipUnitGroupSummaries)
         {
-            var coursePaymentsSummaryPartialViewModel = new CoursePaymentsSummaryPartialViewModel(apprenticeshipUnitGroupSummary, Model.Data.HashedAccountId, Model.Data.UkPrn, Model.Data.FromDate, Model.Data.ToDate, Model.Data.ShowNonCoInvesmentPaymentsTotal);
+            var coursePaymentsSummaryPartialViewModel = new CoursePaymentsSummaryPartialViewModel(apprenticeshipUnitGroupSummary, Model.Data.HashedAccountId, Model.Data.UkPrn, Model.Data.FromDate, Model.Data.ToDate, Model.Data.ShowNonCoInvestmentPaymentsTotal);
 
             <partial name="_TransactionPaymentLine" model="coursePaymentsSummaryPartialViewModel"/>
         }
 
         <tr class="govuk-table__row">
             <td data-label="Totals" class="app-table__cell--transparent"> </td>
-            @if (Model.Data.ShowNonCoInvesmentPaymentsTotal)
+            @if (Model.Data.ShowNonCoInvestmentPaymentsTotal)
             {
                 <td data-label="Paid from levy" class="govuk-table__cell govuk-table__cell--numeric app-table__cell--total">@Model.Data.LevyPaymentsTotalApprenticeshipUnits.ToString("C2", culture)</td>
             }
@@ -112,7 +119,7 @@
         </tr>
 
         <tr class="govuk-table__row app-table__row--spacer" aria-hidden="true">
-            <td class="app-table__cell--transparent" colspan="@(Model.Data.ShowNonCoInvesmentPaymentsTotal ? "2" : "1")">&nbsp;</td>
+            <td class="app-table__cell--transparent" colspan="@(Model.Data.ShowNonCoInvestmentPaymentsTotal ? "2" : "1")">&nbsp;</td>
             <td class="app-table__cell--transparent app-table__cell--highlight" colspan="2">&nbsp;</td>
             <td class="app-table__cell--transparent" colspan="2">&nbsp;</td>
         </tr>

--- a/src/SFA.DAS.EmployerFinance/Data/TransactionRepository.cs
+++ b/src/SFA.DAS.EmployerFinance/Data/TransactionRepository.cs
@@ -11,17 +11,8 @@ using TransactionItemType = SFA.DAS.EmployerFinance.Models.Transaction.Transacti
 
 namespace SFA.DAS.EmployerFinance.Data;
 
-public class TransactionRepository : ITransactionRepository
+public class TransactionRepository(IMapper mapper, Lazy<EmployerFinanceDbContext> db) : ITransactionRepository
 {
-    private readonly IMapper _mapper;
-    private readonly Lazy<EmployerFinanceDbContext> _db;
-
-    public TransactionRepository(IMapper mapper, Lazy<EmployerFinanceDbContext> db)
-    {
-        _mapper = mapper;
-        _db = db;
-    }
-
     public Task CreateTransferTransactions(IEnumerable<TransferTransactionLine> transactions)
     {
         var transactionTable = CreateTransferTransactionDataTable(transactions);
@@ -30,10 +21,10 @@ public class TransactionRepository : ITransactionRepository
         parameters.Add("@transferTransactions",
             transactionTable.AsTableValuedParameter("[employer_financial].[TransferTransactionsTable]"));
 
-        return _db.Value.Database.GetDbConnection().ExecuteAsync(
+        return db.Value.Database.GetDbConnection().ExecuteAsync(
             sql: "[employer_financial].[CreateAccountTransferTransactions]",
             param: parameters,
-            transaction: _db.Value.Database.CurrentTransaction?.GetDbTransaction(),
+            transaction: db.Value.Database.CurrentTransaction?.GetDbTransaction(),
             commandType: CommandType.StoredProcedure);
     }
 
@@ -44,10 +35,10 @@ public class TransactionRepository : ITransactionRepository
         parameters.Add("@accountId", accountId, DbType.Int64);
         parameters.Add("@fromDate", new DateTime(fromDate.Year, fromDate.Month, fromDate.Day), DbType.DateTime);
 
-        return await _db.Value.Database.GetDbConnection().ExecuteScalarAsync<int>(
+        return await db.Value.Database.GetDbConnection().ExecuteScalarAsync<int>(
             sql: "[employer_financial].[GetPreviousTransactionsCount]",
             param: parameters,
-            transaction: _db.Value.Database.CurrentTransaction?.GetDbTransaction(),
+            transaction: db.Value.Database.CurrentTransaction?.GetDbTransaction(),
             commandType: CommandType.StoredProcedure);
 
     }
@@ -57,10 +48,10 @@ public class TransactionRepository : ITransactionRepository
         var parameters = new DynamicParameters();
         parameters.Add("@accountId", accountId, DbType.Int64);
 
-        return _db.Value.Database.GetDbConnection().QuerySingleAsync<decimal>(
+        return db.Value.Database.GetDbConnection().QuerySingleAsync<decimal>(
             sql: "SELECT ISNULL(SUM(Amount),0) FROM [employer_financial].[TransactionLine] WHERE AccountId = @accountId AND TransactionType in (1, 2, 3, 4, 5)",
             param: parameters,
-            transaction: _db.Value.Database.CurrentTransaction?.GetDbTransaction(),
+            transaction: db.Value.Database.CurrentTransaction?.GetDbTransaction(),
             commandType: CommandType.Text);
     }
 
@@ -72,49 +63,13 @@ public class TransactionRepository : ITransactionRepository
         parameters.Add("@fromDate", new DateTime(fromDate.Year, fromDate.Month, fromDate.Day), DbType.DateTime);
         parameters.Add("@toDate", new DateTime(toDate.Year, toDate.Month, toDate.Day, 23, 59, 59), DbType.DateTime);
 
-        var result = await _db.Value.Database.GetDbConnection().QueryAsync<TransactionEntity>(
+        var result = await db.Value.Database.GetDbConnection().QueryAsync<TransactionEntity>(
             sql: "[employer_financial].[GetTransactionLines_ByAccountId]",
             param: parameters,
-            transaction: _db.Value.Database.CurrentTransaction?.GetDbTransaction(),
+            transaction: db.Value.Database.CurrentTransaction?.GetDbTransaction(),
             commandType: CommandType.StoredProcedure);
 
         return MapTransactions(result);
-    }
-
-    private static DataTable CreateTransferTransactionDataTable(IEnumerable<TransferTransactionLine> transactions)
-    {
-        var table = new DataTable();
-
-        table.Columns.AddRange(new[]
-        {
-            new DataColumn("AccountId", typeof(long)),
-            new DataColumn("SenderAccountId", typeof(long)),
-            new DataColumn("SenderAccountName", typeof(string)),
-            new DataColumn("ReceiverAccountId", typeof(long)),
-            new DataColumn("ReceiverAccountName", typeof(string)),
-            new DataColumn("PeriodEnd", typeof(string)),
-            new DataColumn("Amount", typeof(decimal)),
-            new DataColumn("TransactionType", typeof(short)),
-            new DataColumn("TransactionDate", typeof(DateTime)),
-        });
-
-        foreach (var transaction in transactions)
-        {
-            table.Rows.Add(
-                transaction.AccountId,
-                transaction.SenderAccountId,
-                transaction.SenderAccountName,
-                transaction.ReceiverAccountId,
-                transaction.ReceiverAccountName,
-                transaction.PeriodEnd,
-                transaction.Amount,
-                (short)TransactionItemType.Transfer,
-                transaction.TransactionDate);
-        }
-
-        table.AcceptChanges();
-
-        return table;
     }
 
     public async Task<TransactionLine[]> GetAccountTransactionByProviderAndDateRange(long accountId, long ukprn, DateTime fromDate, DateTime toDate)
@@ -126,42 +81,13 @@ public class TransactionRepository : ITransactionRepository
         parameters.Add("@fromDate", new DateTime(fromDate.Year, fromDate.Month, fromDate.Day), DbType.DateTime);
         parameters.Add("@toDate", new DateTime(toDate.Year, toDate.Month, toDate.Day, 23, 59, 59), DbType.DateTime);
 
-        var result = await _db.Value.Database.GetDbConnection().QueryAsync<TransactionEntity>(
+        var result = await db.Value.Database.GetDbConnection().QueryAsync<TransactionEntity>(
             sql: "[employer_financial].[GetPaymentDetail_ByAccountProviderAndDateRange]",
             param: parameters,
-            transaction: _db.Value.Database.CurrentTransaction?.GetDbTransaction(),
+            transaction: db.Value.Database.CurrentTransaction?.GetDbTransaction(),
             commandType: CommandType.StoredProcedure);
 
         return MapTransactions(result);
-    }
-
-    private TransactionLine[] MapTransactions(IEnumerable<TransactionEntity> transactionEntities)
-    {
-        return transactionEntities.Select(entity =>
-        {
-            switch (entity.TransactionType)
-            {
-                case TransactionItemType.Declaration:
-                case TransactionItemType.TopUp:
-                    return _mapper.Map<LevyDeclarationTransactionLine>(entity);
-
-                case TransactionItemType.Payment:
-                    return _mapper.Map<PaymentTransactionLine>(entity);
-
-                case TransactionItemType.Transfer:
-                    return _mapper.Map<TransferTransactionLine>(entity);
-
-                case TransactionItemType.ExpiredFund:
-                case TransactionItemType.ShortExpiredFund:
-                    return _mapper.Map<ExpiredFundTransactionLine>(entity);
-                
-                case TransactionItemType.Unknown:
-                    return _mapper.Map<TransactionLine>(entity);
-
-                default:
-                    throw new InvalidOperationException($"Unable to map from {entity.TransactionType}.");
-            }
-        }).ToArray();
     }
 
     public async Task<TransactionLine[]> GetAccountCoursePaymentsByDateRange(long accountId, long ukprn, string courseName, int? courseLevel, int? pathwayCode, DateTime fromDate, DateTime toDate)
@@ -176,10 +102,10 @@ public class TransactionRepository : ITransactionRepository
         parameters.Add("@fromDate", new DateTime(fromDate.Year, fromDate.Month, fromDate.Day), DbType.DateTime);
         parameters.Add("@toDate", new DateTime(toDate.Year, toDate.Month, toDate.Day, 23, 59, 59), DbType.DateTime);
 
-        var result = await _db.Value.Database.GetDbConnection().QueryAsync<TransactionEntity>(
+        var result = await db.Value.Database.GetDbConnection().QueryAsync<TransactionEntity>(
             sql: "[employer_financial].[GetPaymentDetail_ByAccountProviderCourseAndDateRange]",
             param: parameters,
-            transaction: _db.Value.Database.CurrentTransaction?.GetDbTransaction(),
+            transaction: db.Value.Database.CurrentTransaction?.GetDbTransaction(),
             commandType: CommandType.StoredProcedure);
 
         return MapTransactions(result);
@@ -192,10 +118,10 @@ public class TransactionRepository : ITransactionRepository
         parameters.Add("@fromDate", new DateTime(fromDate.Year, fromDate.Month, fromDate.Day), DbType.DateTime);
         parameters.Add("@toDate", new DateTime(toDate.Year, toDate.Month, toDate.Day, 23, 59, 59), DbType.DateTime);
 
-        var result = await _db.Value.Database.GetDbConnection().QueryAsync<TransactionEntity>(
+        var result = await db.Value.Database.GetDbConnection().QueryAsync<TransactionEntity>(
             sql: "[employer_financial].[GetLevyDetail_ByAccountIdAndDateRange]",
             param: parameters,
-            transaction: _db.Value.Database.CurrentTransaction?.GetDbTransaction(),
+            transaction: db.Value.Database.CurrentTransaction?.GetDbTransaction(),
             commandType: CommandType.StoredProcedure);
 
         return MapTransactions(result);
@@ -209,10 +135,10 @@ public class TransactionRepository : ITransactionRepository
         parameters.Add("@accountId", accountId, DbType.Int64);
         parameters.Add("@periodEnd", periodEnd, DbType.String);
 
-        return _db.Value.Database.GetDbConnection().ExecuteScalarAsync<string>(
+        return db.Value.Database.GetDbConnection().ExecuteScalarAsync<string>(
             sql: "[employer_financial].[GetProviderName]",
             param: parameters,
-            transaction: _db.Value.Database.CurrentTransaction?.GetDbTransaction(),
+            transaction: db.Value.Database.CurrentTransaction?.GetDbTransaction(),
             commandType: CommandType.StoredProcedure);
 
     }
@@ -225,12 +151,12 @@ public class TransactionRepository : ITransactionRepository
         parameters.Add("@fromDate", fromDate, DbType.DateTime);
         parameters.Add("@toDate", toDate, DbType.DateTime);
 
-        var result = await _db.Value.Database
+        var result = await db.Value.Database
             .GetDbConnection()
             .QueryAsync<TransactionDownloadLine>(
                 sql: "[employer_financial].[GetAllTransactionDetailsForAccountByDate]",
                 param: parameters,
-                transaction: _db.Value.Database.CurrentTransaction?.GetDbTransaction(),
+                transaction: db.Value.Database.CurrentTransaction?.GetDbTransaction(),
                 commandType: CommandType.StoredProcedure);
 
         var hmrcDateService = new HmrcDateService();
@@ -252,11 +178,11 @@ public class TransactionRepository : ITransactionRepository
         var parameters = new DynamicParameters();
         parameters.Add("@AccountId", accountId, DbType.Int64);
 
-        return _db.Value.Database
+        return db.Value.Database
             .GetDbConnection()
             .ExecuteScalarAsync<decimal>(sql: "[employer_financial].[GetTotalSpendForLastYearByAccountId]",
                 param: parameters,
-                transaction: _db.Value.Database.CurrentTransaction?.GetDbTransaction(),
+                transaction: db.Value.Database.CurrentTransaction?.GetDbTransaction(),
                 commandType: CommandType.StoredProcedure);
     }
 
@@ -266,44 +192,91 @@ public class TransactionRepository : ITransactionRepository
 
         parameters.Add("@AccountId", accountId, DbType.Int64);
 
-        var result = await _db.Value.Database
+        var result = await db.Value.Database
             .GetDbConnection()
             .QueryAsync<TransactionSummary>(
                 sql: "[employer_financial].[GetTransactionSummary_ByAccountId]",
                 param: parameters,
-                transaction: _db.Value.Database.CurrentTransaction?.GetDbTransaction(),
+                transaction: db.Value.Database.CurrentTransaction?.GetDbTransaction(),
                 commandType: CommandType.StoredProcedure);
 
         return result.ToList();
     }
     public async Task<TransactionLine[]> GetExistingTransactionLines(long accountId, string periodEnd, int transactionType)
     {
-        var query = _db.Value.Transactions.Where(t => t.AccountId == accountId
+        var query = db.Value.Transactions.Where(t => t.AccountId == accountId
                                                    && t.PeriodEnd == periodEnd
                                                    && t.TransactionType == (TransactionItemType)transactionType);
         var transactionLines = await query.ToListAsync();
         return MapTransactionLines(transactionLines);
     }
+
+    private TransactionLine[] MapTransactions(IEnumerable<TransactionEntity> transactionEntities)
+    {
+        return transactionEntities.Select(entity =>
+        {
+            return entity.TransactionType switch
+            {
+                TransactionItemType.Declaration or TransactionItemType.TopUp => mapper
+                    .Map<LevyDeclarationTransactionLine>(entity),
+                TransactionItemType.Payment => mapper.Map<PaymentTransactionLine>(entity),
+                TransactionItemType.Transfer => mapper.Map<TransferTransactionLine>(entity),
+                TransactionItemType.ExpiredFund or TransactionItemType.ShortExpiredFund => mapper
+                    .Map<ExpiredFundTransactionLine>(entity),
+                TransactionItemType.Unknown => mapper.Map<TransactionLine>(entity),
+                _ => throw new InvalidOperationException($"Unable to map from {entity.TransactionType}.")
+            };
+        }).ToArray();
+    }
+
     private TransactionLine[] MapTransactionLines(IEnumerable<TransactionLineEntity> transactionLineEntities)
     {
         return transactionLineEntities.Select(entity =>
         {
-            switch (entity.TransactionType)
+            return entity.TransactionType switch
             {
-                case TransactionItemType.Declaration:
-                case TransactionItemType.TopUp:
-                    return _mapper.Map<LevyDeclarationTransactionLine>(entity);
-                case TransactionItemType.Payment:
-                    return _mapper.Map<PaymentTransactionLine>(entity);
-                case TransactionItemType.Transfer:
-                    return _mapper.Map<TransferTransactionLine>(entity);
-                case TransactionItemType.ExpiredFund:
-                    return _mapper.Map<ExpiredFundTransactionLine>(entity);
-                case TransactionItemType.Unknown:
-                    return _mapper.Map<TransactionLine>(entity);
-                default:
-                    throw new InvalidOperationException($"Unable to map from {entity.TransactionType}.");
-            }
+                TransactionItemType.Declaration or TransactionItemType.TopUp => mapper.Map<LevyDeclarationTransactionLine>(entity),
+                TransactionItemType.Payment => mapper.Map<PaymentTransactionLine>(entity),
+                TransactionItemType.Transfer => mapper.Map<TransferTransactionLine>(entity),
+                TransactionItemType.ExpiredFund => mapper.Map<ExpiredFundTransactionLine>(entity),
+                TransactionItemType.Unknown => mapper.Map<TransactionLine>(entity),
+                _ => throw new InvalidOperationException($"Unable to map from {entity.TransactionType}.")
+            };
         }).ToArray();
+    }
+
+    private static DataTable CreateTransferTransactionDataTable(IEnumerable<TransferTransactionLine> transactions)
+    {
+        var table = new DataTable();
+
+        table.Columns.AddRange([
+            new DataColumn("AccountId", typeof(long)),
+            new DataColumn("SenderAccountId", typeof(long)),
+            new DataColumn("SenderAccountName", typeof(string)),
+            new DataColumn("ReceiverAccountId", typeof(long)),
+            new DataColumn("ReceiverAccountName", typeof(string)),
+            new DataColumn("PeriodEnd", typeof(string)),
+            new DataColumn("Amount", typeof(decimal)),
+            new DataColumn("TransactionType", typeof(short)),
+            new DataColumn("TransactionDate", typeof(DateTime))
+        ]);
+
+        foreach (var transaction in transactions)
+        {
+            table.Rows.Add(
+                transaction.AccountId,
+                transaction.SenderAccountId,
+                transaction.SenderAccountName,
+                transaction.ReceiverAccountId,
+                transaction.ReceiverAccountName,
+                transaction.PeriodEnd,
+                transaction.Amount,
+                (short)TransactionItemType.Transfer,
+                transaction.TransactionDate);
+        }
+
+        table.AcceptChanges();
+
+        return table;
     }
 }

--- a/src/SFA.DAS.EmployerFinance/Models/Payments/PaymentTransactionLine.cs
+++ b/src/SFA.DAS.EmployerFinance/Models/Payments/PaymentTransactionLine.cs
@@ -22,6 +22,7 @@ public class PaymentTransactionLine : TransactionLine
     public decimal EmployerCoInvestmentAmount { get; set; }
     public LearningType? LearningType { get; set; }
     public long? CohortId { get; set; }
+    public string SenderAccountName { get; set; }
 
     public bool IsCoInvested => SfaCoInvestmentAmount != 0 || EmployerCoInvestmentAmount != 0;
 }

--- a/src/SFA.DAS.EmployerFinance/Queries/FindAccountProviderPayments/FindAccountProviderPaymentsHandler.cs
+++ b/src/SFA.DAS.EmployerFinance/Queries/FindAccountProviderPayments/FindAccountProviderPaymentsHandler.cs
@@ -42,6 +42,7 @@ public class FindAccountProviderPaymentsHandler(
             ProviderName = firstTransaction.ProviderName,
             TransactionDate = firstTransaction.TransactionDate,
             DateCreated = firstTransaction.DateCreated,
+            SenderAccountName = firstTransaction.SenderAccountName,
             Transactions = transactions.ToList(),
             Total = transactions.Sum(c => c.LineAmount)
         };

--- a/src/SFA.DAS.EmployerFinance/Queries/FindAccountProviderPayments/FindAccountProviderPaymentsResponse.cs
+++ b/src/SFA.DAS.EmployerFinance/Queries/FindAccountProviderPayments/FindAccountProviderPaymentsResponse.cs
@@ -10,4 +10,5 @@ public class FindAccountProviderPaymentsResponse
     public List<PaymentTransactionLine> Transactions { get; set; }
     public decimal Total { get; set; }
     public string CohortReference { get; set; }
+    public string SenderAccountName { get; set; }
 }

--- a/src/SFA.DAS.EmployerFinance/Queries/GetEmployerAccountTransactions/GetEmployerAccountTransactionsHandler.cs
+++ b/src/SFA.DAS.EmployerFinance/Queries/GetEmployerAccountTransactions/GetEmployerAccountTransactionsHandler.cs
@@ -56,33 +56,31 @@ public class GetEmployerAccountTransactionsHandler(
 
     private async Task GenerateTransactionDescription(TransactionLine transaction)
     {
-        if (transaction.GetType() == typeof(LevyDeclarationTransactionLine))
+        switch (transaction)
         {
-            transaction.Description = transaction.Amount >= 0 ? "Levy declared this month" : "Levy adjustment";
-        }
-        else if (transaction.GetType() == typeof(PaymentTransactionLine))
-        {
-            var paymentTransaction = (PaymentTransactionLine)transaction;
+            case LevyDeclarationTransactionLine levyTransaction:
+                transaction.Description = levyTransaction.Amount >= 0 ? "Levy declared this month" : "Levy adjustment";
+                break;
 
-            transaction.Description = await GetPaymentTransactionDescription(paymentTransaction);
-        }
-        else if (transaction.GetType() == typeof(ExpiredFundTransactionLine))
-        {
-            transaction.Description = "Expired levy this month";
-        }
-        else if (transaction.GetType() == typeof(TransferTransactionLine))
-        {
-            var transferTransaction = (TransferTransactionLine)transaction;
+            case PaymentTransactionLine paymentTransaction:
+                transaction.Description = await GetPaymentTransactionDescription(paymentTransaction);
+                break;
 
-            if (transferTransaction.TransactionAccountIsTransferSender)
-            {
-                transaction.Description = $"Transfer sent to {transferTransaction.ReceiverAccountName}";
-            }
-            else
-            {
-                transaction.Description = $"Transfer received from {transferTransaction.SenderAccountName}";
-                transaction.TransferSourceDescription = $"Paid using transfer from {transferTransaction.SenderAccountName}";
-            }
+            case ExpiredFundTransactionLine:
+                transaction.Description = "Expired levy this month";
+                break;
+
+            case TransferTransactionLine transferTransaction:
+                if (transferTransaction.TransactionAccountIsTransferSender)
+                {
+                    transaction.Description = $"Transfer sent to {transferTransaction.ReceiverAccountName}";
+                }
+                else
+                {
+                    transaction.Description = $"Transfer received from {transferTransaction.SenderAccountName}";
+                    transaction.TransferSourceDescription = $"Paid using transfer from {transferTransaction.SenderAccountName}";
+                }
+                break;
         }
     }
 


### PR DESCRIPTION
Show transfer sender name on provider payment summary

Adds support for displaying the transfer sender account name on the provider payment summary for non-levy employers. Updates the SQL query, domain models, orchestrator, handler, and view model to pass and expose the sender name. Updates the Razor view to conditionally show the sender. Renames `ShowNonCoInvesmentPaymentsTotal` for consistency, refactors repository/controller constructors, modernizes mapping logic, and updates unit tests.